### PR TITLE
Update vcpkg ref

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,8 +14,8 @@ concurrency:
 
 env:
   VCPKG_REPO: microsoft/vcpkg
-  # 20.10.2022
-  VCPKG_REF: 030c53833b977f1580b2a4817bb22edbdde606d4
+  # 02.12.2022
+  VCPKG_REF: 163fe7bd3d67c41200617caaa245b5ba2ba854e6
 
 jobs:
   sdl1-core:


### PR DESCRIPTION
List of changes:

* sdl2: 2.24.0 -> 2.26.1 (https://github.com/libsdl-org/SDL/issues/6391 that was a reason for https://github.com/ihhub/fheroes2/issues/5984 was (hopefully) fixed);
* sdl2-image: 2.0.5 -> 2.6.2;
* libpng: 1.6.37 -> 1.6.38;
* zlib: 1.2.12 -> 1.2.13 (see [CVE-2022-37434](https://nvd.nist.gov/vuln/detail/CVE-2022-37434)).
