### PR TITLE
Android: compileSdkVersion -> compileSdk

### DIFF
--- a/android/SDL2/build.gradle
+++ b/android/SDL2/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 android {
     namespace 'org.libsdl.app'
 
-    compileSdkVersion 34
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 19


### PR DESCRIPTION
`compileSdkVersion` is deprecated.