### PR TITLE
Update Windows & Android dependencies

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   SDL2_REPO: libsdl-org/SDL
-  SDL2_REF: release-2.28.5
+  SDL2_REF: release-2.30.0
   #
   SDL2_MIXER_REPO: libsdl-org/SDL_mixer
   SDL2_MIXER_REF: release-2.8.0

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,7 +20,7 @@ env:
   SDL2_REF: release-2.28.5
   #
   SDL2_MIXER_REPO: libsdl-org/SDL_mixer
-  SDL2_MIXER_REF: release-2.6.3
+  SDL2_MIXER_REF: release-2.8.0
 
 jobs:
   android:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 env:
   SDL2_REPO: libsdl-org/SDL
   SDL2_REF: release-2.28.5

--- a/.github/workflows/pr_author_auto_assign.yml
+++ b/.github/workflows/pr_author_auto_assign.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened, reopened]
 
+permissions:
+  pull-requests: write
+
 jobs:
   assign:
     name: PR author auto assign

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,8 +17,8 @@ permissions:
 
 env:
   VCPKG_REPO: microsoft/vcpkg
-  # 06.02.2024
-  VCPKG_REF: 42bb0d9e8d4cf33485afb9ee2229150f79f61a1f
+  # 08.02.2024
+  VCPKG_REF: 3f806e04fdcf30df33c7b445590c9ac13afef946
 
 jobs:
   sdl2:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 env:
   VCPKG_REPO: microsoft/vcpkg
   # 09.01.2024

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,8 +17,8 @@ permissions:
 
 env:
   VCPKG_REPO: microsoft/vcpkg
-  # 09.01.2024
-  VCPKG_REF: 3bc5ff7f7ab72b57f0945d35bbbdaac2060bc268
+  # 06.02.2024
+  VCPKG_REF: 42bb0d9e8d4cf33485afb9ee2229150f79f61a1f
 
 jobs:
   sdl2:

--- a/android/Application.mk
+++ b/android/Application.mk
@@ -4,3 +4,5 @@ APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_PLATFORM := android-19
 # Build SDL2_mixer with TiMidity
 SUPPORT_MID_TIMIDITY := true
+# Build SDL2_mixer without WavPack
+SUPPORT_WAVPACK := false

--- a/windows/sdl2.bat
+++ b/windows/sdl2.bat
@@ -47,6 +47,7 @@ call :copy_dll "pcre*"          && ^
 call :copy_dll "SDL2*"          && ^
 call :copy_dll "sndfile*"       && ^
 call :copy_dll "vorbis*"        && ^
+call :copy_dll "wavpack*"       && ^
 call :copy_dll "zlib*"          || ^
 exit /B 1
 


### PR DESCRIPTION
General:

* Limit workflow permissions;

Android:

* SDL2 2.28.5 -> 2.30.0;
* SDL2_mixer 2.6.3 -> 2.8.0;

Windows:

* SDL2 2.28.5 -> 2.30.0;
* SDL2_mixer 2.6.3 -> 2.8.0;
* wavpack 5.6.0 (new SDL_mixer dependency);
* GLib 2.78.1 -> 2.78.4;
* zlib 1.3 -> 1.3.1.