### PR TITLE
Windows: disable the default wavpack support for SDL_mixer

### DIFF
--- a/windows/sdl2.bat
+++ b/windows/sdl2.bat
@@ -24,14 +24,13 @@ if not exist "%OUTPUT_DIR%\lib\debug\%PLATFORM%" ( mkdir "%OUTPUT_DIR%\lib\debug
 
 echo Copying files...
 
-call :copy_dll "FLAC*"    && ^
-call :copy_dll "mpg123*"  && ^
-call :copy_dll "ogg*"     && ^
-call :copy_dll "opus*"    && ^
-call :copy_dll "SDL2*"    && ^
-call :copy_dll "vorbis*"  && ^
-call :copy_dll "wavpack*" && ^
-call :copy_dll "zlib*"    || ^
+call :copy_dll "FLAC*"   && ^
+call :copy_dll "mpg123*" && ^
+call :copy_dll "ogg*"    && ^
+call :copy_dll "opus*"   && ^
+call :copy_dll "SDL2*"   && ^
+call :copy_dll "vorbis*" && ^
+call :copy_dll "zlib*"   || ^
 exit /B 1
 
 xcopy /Y /Q "%VCPKG_DIR%\installed\%TRIPLET%\debug\lib\SDL2*.lib"             "%OUTPUT_DIR%\lib\debug\%PLATFORM%" && ^

--- a/windows/sdl2.bat
+++ b/windows/sdl2.bat
@@ -15,7 +15,7 @@ echo Building sdl2 and dependencies...
 
 set VCPKG_ROOT=%VCPKG_DIR%
 
-"%VCPKG_DIR%\vcpkg" --triplet "%TRIPLET%" install sdl2 sdl2-mixer[libflac,mpg123,opusfile,timidity] sdl2-image zlib || ^
+"%VCPKG_DIR%\vcpkg" --triplet "%TRIPLET%" install sdl2 sdl2-mixer[core,libflac,mpg123,opusfile,timidity] sdl2-image zlib || ^
 exit /B 1
 
 if not exist "%OUTPUT_DIR%\include\SDL2"         ( mkdir "%OUTPUT_DIR%\include\SDL2"         || exit /B 1 )


### PR DESCRIPTION
As far as I know, music for HoMM2 has never been supplied in WavPack format.